### PR TITLE
Fixing config validation failure on booleans

### DIFF
--- a/private/ObjectProperty.ps1
+++ b/private/ObjectProperty.ps1
@@ -13,7 +13,8 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `"$value`""
     } elseif ($fieldType -eq [Boolean]) {
         Write-Debug "Setting as Boolean value"
-        $exp = "`$obj.$path = `$$value"
+        if($dryRun){$value = $false}
+        $exp = "`$obj.$path = `"$value`""
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
         $exp = "`$obj.$path = `"$value`""


### PR DESCRIPTION
When running Test-AdfCode, if your deployment config files contain Booleans, the script will fail with the following error:
```
Validation of config file completed.
ERROR: The variable '$123' cannot be retrieved because it has not been set.
```

This occurs because the ObjectProperty.ps1 script receives "123" as the "$value" var when "$dryRun" is "$true".  Setting "$value" = "$false" and correcting "$exp" so that it receives "$false" as its value instead of "$$false".  