### PR TITLE
Config boolean issue

### DIFF
--- a/private/Update-PropertiesFromFile.ps1
+++ b/private/Update-PropertiesFromFile.ps1
@@ -135,7 +135,6 @@ function Update-PropertiesForObject {
         }
     }
 
-    if ($dryRun) { $value = 123 }
     if ($validPath) {
         switch -Exact ($action)
         {


### PR DESCRIPTION
Removing Dry-Run $value setting causing config validation to throw an error when Boolean variables are included.