### PR TITLE
Fixed 2 issues in Validation of ADF files (ver.1.2)

### DIFF
--- a/azure.datafactory.tools.psd1
+++ b/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.2.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2023-02-24
+### Fixed
+* Validation of ADF files fails when JSON contains property with single quote #287
+* Validation of ADF files fails when a pipeline has reference to Synapse notebook
+
 ## [1.1.0] - 2023-02-23
 * Support for new SynapseNotebook activity #279
 

--- a/private/Get-ReferencedObjects.ps1
+++ b/private/Get-ReferencedObjects.ps1
@@ -39,6 +39,7 @@ function Find-RefObject($node, $list) {
             Write-Debug ("-"+"."*2*$script:ind + "$name")
             if ($name.Length -gt 0)
             {
+                $name = $name -replace "'", "''"
                 Invoke-Expression "`$in = `$node.`'$name`'"
                 Find-RefObject -node $in -list $list
             }

--- a/public/Test-AdfCode.ps1
+++ b/public/Test-AdfCode.ps1
@@ -66,7 +66,7 @@ function Test-AdfCode {
             $_.DependsOn | ForEach-Object {
                 Write-Verbose -Message "  - Checking dependency: [$_]"
                 $ref_arr = $adf.GetObjectsByFullName("$_")
-                if ($ref_arr.Count -eq 0) {
+                if ($ref_arr.Count -eq 0 -and $_ -notlike "notebook.*") {
                     $result.ErrorCount += 1
                     Write-Error -Message "Couldn't find referenced object $_." -ErrorAction 'Continue'
                 }

--- a/test/Test-AdfCode.Tests.ps1
+++ b/test/Test-AdfCode.Tests.ps1
@@ -48,6 +48,15 @@ InModuleScope azure.datafactory.tools {
         }
     }
 
+    Describe 'Test-AdfCode' -Tag 'Unit' {
+        It 'Should parse properly adf2 code' {
+            $DataFactoryName = "adf2"
+            $RootFolder = Join-Path -Path $PSScriptRoot -ChildPath $DataFactoryName
+            { 
+                $script:res = Test-AdfCode -RootFolder $RootFolder
+            } | Should -Not -Throw
+        }
+    }
 
 
 

--- a/test/adf2/pipeline/SynapseNotebook1.json
+++ b/test/adf2/pipeline/SynapseNotebook1.json
@@ -22,7 +22,8 @@
                         },
                         "type": "NotebookReference"
                     },
-                    "snapshot": true
+                    "snapshot": true,
+                    "Single'Quote": true
                 },
                 "linkedServiceName": {
                     "referenceName": "LS_AzureSynapseArtifacts1",


### PR DESCRIPTION
## [1.2.0] - 2023-02-24
### Fixed
* Validation of ADF files fails when JSON contains property with single quote #287
* Validation of ADF files fails when a pipeline has reference to Synapse notebook
