### PR TITLE
Fix #301

### DIFF
--- a/test/BigFactorySample2/deployment/config-c100.json
+++ b/test/BigFactorySample2/deployment/config-c100.json
@@ -27,5 +27,11 @@
         "name": "$.properties.typeProperties.baseUrl",
         "value": "https://keyvault-$($Env:ProjectName)-$($Env:Environment).vault.azure.net/"
       }
+    ],
+    "TR_RunEveryDay": [
+      {
+        "name": "$.properties.typeProperties.recurrence.startTime",
+        "value": "2020-06-01T23:22:00.000Z"
+      }
     ]
   }

--- a/test/Update-PropertiesFromFile.Tests.ps1
+++ b/test/Update-PropertiesFromFile.Tests.ps1
@@ -291,7 +291,7 @@ InModuleScope azure.datafactory.tools {
                 $script:ls = Get-AdfObjectByName -adf $script:adf -name "LS_AzureKeyVault" -type "linkedService"
                 $script:ls.Body.properties.typeProperties.baseUrl | Should -Be "https://keyvault-$($Env:ProjectName)-$($Env:Environment).vault.azure.net/"
                 $script:ls = Get-AdfObjectByName -adf $script:adf -name "TR_RunEveryDay" -type "trigger"
-                $script:ls.Body.properties.typeProperties.recurrence.startTime | Should -Be "2020-06-01T23:22:00.000Z"
+                $script:ls.Body.properties.typeProperties.recurrence.startTime | Should -Be "2020-06-01T23:22:00Z"
 
                 Get-Member -InputObject $script:lsdbr.Body.properties.typeProperties -name "encryptedCredential" -Membertype "Properties" | Should -Be $null
             }

--- a/test/Update-PropertiesFromFile.Tests.ps1
+++ b/test/Update-PropertiesFromFile.Tests.ps1
@@ -290,6 +290,8 @@ InModuleScope azure.datafactory.tools {
                 $script:lsdbr.Body.properties.typeProperties.domain | Should -Be "https://$($Env:Region).azuredatabricks.net"
                 $script:ls = Get-AdfObjectByName -adf $script:adf -name "LS_AzureKeyVault" -type "linkedService"
                 $script:ls.Body.properties.typeProperties.baseUrl | Should -Be "https://keyvault-$($Env:ProjectName)-$($Env:Environment).vault.azure.net/"
+                $script:ls = Get-AdfObjectByName -adf $script:adf -name "TR_RunEveryDay" -type "trigger"
+                $script:ls.Body.properties.typeProperties.recurrence.startTime | Should -Be "2020-06-01T23:22:00.000Z"
 
                 Get-Member -InputObject $script:lsdbr.Body.properties.typeProperties -name "encryptedCredential" -Membertype "Properties" | Should -Be $null
             }


### PR DESCRIPTION
Use explicit datetime formatting to ensure replaced datetime parameters in json files include the timezone identifier, as expected by `Start-AzDataFactoryV2Trigger`.