### PR TITLE
Problem with `Publish-AdfV2FromJson` not yet failing even using errorActionPreference: stop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Fixed
+* `Publish-AdfV2FromJson` no longer silently continues after errors: config path errors (ADFT0010) and deployment failures (e.g. Azure Policy blocks) now propagate as terminating errors to the caller #472
+
 ## [1.15.0] - 2026-05-26
 ### Added
 * Credential type of ADF objects is now supported for deployment via REST API

--- a/private/Deploy-AdfObject.ps1
+++ b/private/Deploy-AdfObject.ps1
@@ -31,7 +31,7 @@ function Deploy-AdfObject {
                 if ($adf.PublishOptions.IgnoreLackOfReferencedObject -eq $true) {
                     Write-Warning "ADFT0006: Referenced object [$type].[$name] was not found. No error raised as user wanted to carry on."
                 } else {
-                    Write-Error "ADFT0005: Referenced object [$type].[$name] was not found."
+                    throw "ADFT0005: Referenced object [$type].[$name] was not found."
                 }
             } elseif ($type -notin [AdfObject]::IgnoreTypes) {
                 Deploy-AdfObject -obj $depobj

--- a/private/Deploy-AdfObjectOnly.ps1
+++ b/private/Deploy-AdfObjectOnly.ps1
@@ -73,7 +73,7 @@ function Deploy-AdfObjectOnly {
                 -Force | Out-Null
             }
             else {
-                Write-Error "ADFT0012: Deployment for this kind of Integration Runtime is not supported yet."
+                throw "ADFT0012: Deployment for this kind of Integration Runtime is not supported yet."
             }
         }
         'linkedService'
@@ -155,7 +155,7 @@ function Deploy-AdfObjectOnly {
         }
         default
         {
-            Write-Error "ADFT0013: Type $($obj.Type) is not supported."
+            throw "ADFT0013: Type $($obj.Type) is not supported."
         }
     }
 

--- a/private/Update-PropertiesFromFile.ps1
+++ b/private/Update-PropertiesFromFile.ps1
@@ -72,7 +72,7 @@ function Update-PropertiesFromFile {
             if ($option.FailsWhenConfigItemNotFound -eq $false) {
                 Write-Warning "Could not find object: $type.$name, skipping..."
             } else {
-                Write-Error -Message "ADFT0007: Could not find object: $type.$name"
+                throw "ADFT0007: Could not find object: $type.$name"
             }
         } else {
             Write-Verbose "- Performing: $action for object(path): $type.$name(properties.$path)"
@@ -131,7 +131,7 @@ function Update-PropertiesForObject {
             Write-Warning "Wrong path defined in config for object(path): $type.$name(properties.$path), skipping..."
         } else {
             $exc = ([System.Data.DataException]::new("ADFT0010: Wrong path defined in config for object(path): $type.$name(properties.$path)"))
-            Write-Error -Exception $exc
+            throw $exc
         }
     }
 

--- a/public/Publish-AdfV2FromJson.ps1
+++ b/public/Publish-AdfV2FromJson.ps1
@@ -272,16 +272,16 @@ function Publish-AdfV2FromJson {
             $adf.Factories[0].ToBeDeployed = $false
         }
     }
-    $adf.AllObjects() | ForEach-Object {
-        Deploy-AdfObject -obj $_
+    foreach ($obj in $adf.AllObjects()) {
+        Deploy-AdfObject -obj $obj
     }
 
     Write-Host "===================================================================================";
     Write-Host "STEP: Deleting objects not in source ..."
     if ($opt.DeleteNotInSource -eq $true) {
         $adfIns = Get-AdfFromService -FactoryName "$DataFactoryName" -ResourceGroupName "$ResourceGroupName"
-        $adfIns.AllObjects() | ForEach-Object {
-            Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $_ -adfInstance $adfIns
+        foreach ($targetObj in $adfIns.AllObjects()) {
+            Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $targetObj -adfInstance $adfIns
         }
         Write-Host "Deleted $($adf.DeletedObjectNames.Count) objects from ADF service."
     } else {

--- a/test/Publish-AdfV2FromJson-ErrorHandling.Tests.ps1
+++ b/test/Publish-AdfV2FromJson-ErrorHandling.Tests.ps1
@@ -1,0 +1,141 @@
+BeforeDiscovery {
+    $ModuleRootPath = $PSScriptRoot | Split-Path -Parent
+    $moduleManifestName = 'azure.datafactory.tools.psd1'
+    $moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
+    Import-Module -Name $moduleManifestPath -Force -Verbose:$false
+}
+
+InModuleScope azure.datafactory.tools {
+    $testHelperPath = $PSScriptRoot | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
+
+    $script:SrcFolder = "$PSScriptRoot\BigFactorySample2"
+    $script:TmpFolder = (New-TemporaryDirectory).FullName
+    $script:RootFolder = Join-Path -Path $script:TmpFolder -ChildPath (Split-Path -Path $script:SrcFolder -Leaf)
+    Copy-Item -Path "$SrcFolder" -Destination "$TmpFolder" -Filter "*.*" -Recurse:$true -Force
+
+    AfterAll {
+        Remove-Item -Path $script:TmpFolder -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    # -------------------------------------------------------------------------
+    # Issue #472 – Scenario 1: wrong property path in config (ADFT0010)
+    #
+    # config-c004-wrongpath.csv contains "typeProperties:baseUrl" (colon
+    # separator instead of dot), which causes Write-Error "ADFT0010" inside
+    # Update-PropertiesForObject.  The error is non-terminating, so the
+    # ForEach-Object loop in Update-PropertiesFromFile swallows it and
+    # Publish-AdfV2FromJson continues to print "deployed successfully".
+    #
+    # Expected fix: the error must propagate as a terminating error so the
+    # caller observes a failure regardless of $ErrorActionPreference scope.
+    # -------------------------------------------------------------------------
+    Describe 'Publish-AdfV2FromJson - Error propagation for wrong config path (Issue #472)' -Tag 'Unit' {
+
+        Context 'When stage config has a wrong property path and FailsWhenPathNotFound is true (default)' {
+
+            It 'Should throw when Publish-AdfV2FromJson is called with -DryRun' {
+                # BUG REPRODUCTION: currently does NOT throw (Write-Error is swallowed).
+                # After fix this test must pass.
+                $o = New-AdfPublishOption
+                # FailsWhenPathNotFound defaults to $true
+                {
+                    Publish-AdfV2FromJson `
+                        -RootFolder $script:RootFolder `
+                        -ResourceGroupName 'rg-test' `
+                        -DataFactoryName 'adf-test' `
+                        -Stage 'c004-wrongpath' `
+                        -Option $o `
+                        -DryRun
+                } | Should -Throw
+            }
+        }
+
+        Context 'When stage config has a wrong property path and FailsWhenPathNotFound is false' {
+
+            It 'Should not throw (wrong path is only a warning)' {
+                $o = New-AdfPublishOption
+                $o.FailsWhenPathNotFound = $false
+                {
+                    Publish-AdfV2FromJson `
+                        -RootFolder $script:RootFolder `
+                        -ResourceGroupName 'rg-test' `
+                        -DataFactoryName 'adf-test' `
+                        -Stage 'c004-wrongpath' `
+                        -Option $o `
+                        -DryRun
+                } | Should -Not -Throw
+            }
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # Issue #472 – Scenario 2: ADF object deployment fails at runtime
+    #
+    # When Deploy-AdfObjectOnly emits a non-terminating Write-Error (e.g. an
+    # Azure Policy block: "RequestDisallowedByPolicy"), the ForEach-Object
+    # pipeline in Publish-AdfV2FromJson absorbs the error and the function
+    # continues to report "deployed successfully".
+    #
+    # Expected fix: the deployment loop must propagate errors so the function
+    # terminates and the caller sees a failure.
+    # -------------------------------------------------------------------------
+    Describe 'Publish-AdfV2FromJson - Error propagation for deployment failure (Issue #472)' -Tag 'Unit' {
+
+        Context 'When an ADF object deployment produces a terminating error' {
+
+            BeforeAll {
+                Mock Get-AzDataFactoryV2 {
+                    [PSCustomObject]@{ Name = 'adf-test'; ResourceGroupName = 'rg-test' }
+                }
+                # Azure cmdlets (e.g. New-AzResource) throw terminating errors for
+                # serious failures like Azure Policy blocks. In PowerShell 5.1 the
+                # ForEach-Object pipeline was absorbing these terminating errors and
+                # allowing the loop to continue, so the function reported success.
+                # The fix replaces ForEach-Object with a foreach statement, which
+                # propagates terminating errors correctly in all PS versions.
+                Mock Deploy-AdfObjectOnly {
+                    throw 'Simulated: RequestDisallowedByPolicy - resource was disallowed by policy'
+                }
+            }
+
+            It 'Should throw when any object deployment fails' {
+                # BUG REPRODUCTION: previously did NOT throw because ForEach-Object
+                # absorbed the terminating error in PS 5.1.
+                # After fix (foreach loop) this test must pass.
+                $o = New-AdfPublishOption
+                $o.StopStartTriggers = $false
+                $o.DeleteNotInSource = $false
+                {
+                    Publish-AdfV2FromJson `
+                        -RootFolder $script:RootFolder `
+                        -ResourceGroupName 'rg-test' `
+                        -DataFactoryName 'adf-test' `
+                        -Option $o
+                } | Should -Throw
+            }
+
+            It 'Should throw even when the caller has not set $ErrorActionPreference to Stop' {
+                # BUG REPRODUCTION: the module scope isolates $ErrorActionPreference
+                # from the caller's script scope, so setting it externally has no effect.
+                # The fix must make the function fail independently of the caller's EAP.
+                $o = New-AdfPublishOption
+                $o.StopStartTriggers = $false
+                $o.DeleteNotInSource = $false
+                $threw = $false
+                # Deliberately NOT using Should -Throw so Pester does not alter EAP
+                try {
+                    Publish-AdfV2FromJson `
+                        -RootFolder $script:RootFolder `
+                        -ResourceGroupName 'rg-test' `
+                        -DataFactoryName 'adf-test' `
+                        -Option $o
+                }
+                catch {
+                    $threw = $true
+                }
+                $threw | Should -BeTrue -Because 'deployment failures must propagate to the caller'
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Fixed
* `Publish-AdfV2FromJson` no longer silently continues after errors: config path errors (ADFT0010) and deployment failures (e.g. Azure Policy blocks) now propagate as terminating errors to the caller #472


### Problem

`Publish-AdfV2FromJson` was silently continuing after errors and always printing `"Azure Data Factory files have been deployed successfully."` even when:

1. A config stage file contained an invalid property path (error `ADFT0010`), and
2. An ADF object deployment failed at runtime (e.g. blocked by Azure Policy: `RequestDisallowedByPolicy`).

Setting `$ErrorActionPreference = 'Stop'` in the calling script had no effect because module functions execute in the module scope, which does not inherit preference variables from the caller's script scope.

Two compounding root causes:

- **`Write-Error` is non-terminating** — errors were written to the error stream but execution continued normally, so the calling script had no way to detect the failure.
- **`ForEach-Object` pipeline absorbs terminating errors in PowerShell 5.1** — even genuinely terminating errors thrown by Azure cmdlets (e.g. `New-AzResource` blocked by policy) were swallowed by the pipeline and did not propagate to the caller.

---

### Changes

#### New test file — `test/Publish-AdfV2FromJson-ErrorHandling.Tests.ps1`

Four unit tests that reproduce the bug and verify the fix, requiring no live Azure connection:

| Test | Purpose |
|------|---------|
| Should throw with wrong config path (`-DryRun`) | Reproduces ADFT0010 not terminating `Publish-AdfV2FromJson` |
| Should NOT throw when `FailsWhenPathNotFound = $false` | Negative test — warning-only mode must still work |
| Should throw when deployment fails (`Should -Throw`) | Reproduces Azure cmdlet terminating error being swallowed by `ForEach-Object` |
| Should throw without Pester's `Should -Throw` (explicit try/catch) | Confirms the fix works independently of caller's `$ErrorActionPreference` |

All four tests were **red before the fix** and are **green after**.

#### `private/Update-PropertiesFromFile.ps1`

- `Write-Error "ADFT0007: ..."` → `throw` — object not found in config (when `FailsWhenConfigItemNotFound = $true`)
- `Write-Error -Exception $exc` → `throw $exc` — invalid property path ADFT0010 (when `FailsWhenPathNotFound = $true`)

#### `private/Deploy-AdfObject.ps1`

- `Write-Error "ADFT0005: ..."` → `throw` — referenced dependency object not found (when `IgnoreLackOfReferencedObject = $false`)

#### `private/Deploy-AdfObjectOnly.ps1`

- `Write-Error "ADFT0012: ..."` → `throw` — unsupported Integration Runtime type
- `Write-Error "ADFT0013: ..."` → `throw` — unsupported ADF object type

#### `public/Publish-AdfV2FromJson.ps1`

- **Deployment loop**: `$adf.AllObjects() | ForEach-Object { Deploy-AdfObject -obj $_ }` → `foreach ($obj in $adf.AllObjects()) { Deploy-AdfObject -obj $obj }`
- **Deletion loop**: same change for `Remove-AdfObjectIfNotInSource`

The `foreach` statement propagates terminating errors from Azure cmdlets correctly in all PowerShell versions; `ForEach-Object` (a pipeline cmdlet) was absorbing them in PowerShell 5.1.

#### `changelog.md`

New entry added under `## Unreleased`.

---

### Why `throw` and not `$PSCmdlet.ThrowTerminatingError()`

`throw` produces an exception that propagates through every layer of the call stack — including `ForEach-Object` pipelines and across module scope boundaries — regardless of `$ErrorActionPreference`. `Write-Error` only becomes terminating if `$ErrorActionPreference = 'Stop'` is set **in the module's own scope**, which the caller cannot control. Using `throw` at the error source removes this dependency entirely.
