### PR TITLE
Bump module version to 1.17.1 and update changelog for timezone handling improvements #402

### DIFF
--- a/azure.datafactory.tools.psd1
+++ b/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.17.0'
+    ModuleVersion = '1.17.1'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.17.0] - 2026-07-01
+## [1.17.1] - 2026-07-01
 ### Fixed
 * Further fixes of `DeleteNotInSource` with deserialization issue #480 
 * `Publish-AdfV2FromJson` no longer silently continues after errors: config path errors (ADFT0010) and deployment failures (e.g. Azure Policy blocks) now propagate as terminating errors to the caller #472
+* Scheduled trigger recurrence times now preserve explicit timezone offsets during config-driven updates, preventing shifted deployment times #402
 
 ## [1.16.0] - 2026-06-06
 ### Fixed

--- a/private/ObjectProperty.ps1
+++ b/private/ObjectProperty.ps1
@@ -25,9 +25,14 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `$$value"
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
-        $datevalue = [DateTime]$value
-        $utcvalue = Get-Date $datevalue -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
-        $exp = "`$obj.$path = `"$utcvalue`""
+        # Keep explicit timezone suffixes unchanged to avoid timezone shifts (Issue #402).
+        if ($value -match '(?i)(Z|[+-][0-9]{2}:[0-9]{2})$') {
+            $exp = "`$obj.$path = `"$value`""
+        } else {
+            $date_value = [DateTime]$value
+            $utc_value = Get-Date $date_value -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+            $exp = "`$obj.$path = `"$utc_value`""
+        }
     } elseif ($fieldType -eq [System.Management.Automation.PSCustomObject]) {
         Write-Debug "Setting as json value"
         $jvalue = ConvertFrom-Json $value

--- a/test/Update-PropertiesFromFile.Tests.ps1
+++ b/test/Update-PropertiesFromFile.Tests.ps1
@@ -375,6 +375,33 @@ InModuleScope azure.datafactory.tools {
 
     }
 
+    Describe 'Update-PropertiesFromFile - Issue #402' -Tag 'Unit','private','issue402' {
+        Context 'When trigger recurrence timestamps contain explicit timezone offsets' {
+            BeforeAll {
+                $script:adf = Import-AdfFromFolder -FactoryName "xyz" -RootFolder "$RootFolder"
+                $script:adf.PublishOptions = New-AdfPublishOption
+
+                $script:configFilePath = Join-Path -Path $script:DeploymentFolder -ChildPath "config-issue-402-timezone.csv"
+                @(
+                    'type,name,path,value'
+                    'trigger,TR_RunEveryDay,"$.properties.typeProperties.recurrence.startTime","2020-06-01T23:22:11.000+10:00"'
+                    'trigger,TR_RunEveryDay,"$.properties.typeProperties.recurrence.endTime","2020-06-05T23:22:11.000+10:00"'
+                ) | Set-Content -Path $script:configFilePath -Encoding UTF8
+
+                Update-PropertiesFromFile -adf $script:adf -stage $script:configFilePath
+                $script:trigger = Get-AdfObjectByName -adf $script:adf -name "TR_RunEveryDay" -type "trigger"
+            }
+
+            It 'Should keep recurrence.startTime offset unchanged' {
+                $script:trigger.Body.properties.typeProperties.recurrence.startTime | Should -Be "2020-06-01T23:22:11.000+10:00"
+            }
+
+            It 'Should keep recurrence.endTime offset unchanged' {
+                $script:trigger.Body.properties.typeProperties.recurrence.endTime | Should -Be "2020-06-05T23:22:11.000+10:00"
+            }
+        }
+    }
+
     Describe 'Publish-AdfV2FromJson with DryRun' -Tag 'Unit','private' {
 
         $cases =  @( @{ configFile = 'config-endpoint.csv' }, @{ configFile = 'config-endpoint2.json' } )


### PR DESCRIPTION
This pull request addresses an important issue with scheduled trigger recurrence times in Azure Data Factory deployments, ensuring that explicit timezone offsets are preserved during configuration updates. It also includes a version bump and new tests to verify the fix.

**Bug fix for timezone offsets in trigger recurrence:**

* Updated `Update-ObjectProperty` in `ObjectProperty.ps1` to preserve explicit timezone suffixes (e.g., `+10:00`, `Z`) when setting `DateTime` properties, preventing unintended timezone shifts during deployment.

**Testing improvements:**

* Added new unit tests in `Update-PropertiesFromFile.Tests.ps1` to verify that timezone offsets in trigger recurrence start and end times remain unchanged after updates (Issue #402).

**Documentation and versioning:**

* Updated `changelog.md` to document the fix for scheduled trigger timezone handling and incremented the version to `1.17.1`.
* Bumped module version in `azure.datafactory.tools.psd1` from `1.17.0` to `1.17.1`.#402