### PR TITLE
Document DryRun/Plan feature and update module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Publish-AdfV2FromJson
    [-Option]              <AdfPublishOption>
    [-Method]              <String>
    [-DryRun]              <Switch>
+   [-Plan]                <Switch>
 ```
 
 Assuming your ADF is named ```SQLPlayerDemo``` and the code is located in ```c:\GitHub\AdfName\```, replace the values for *SubscriptionName*, *ResourceGroupName*, *DataFactoryName* and run the following command using PowerShell CLI:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The main advantage of the module is the ability to publish all the Azure Data Fa
     - [Stage value as full path to CSV config file](#stage-value-as-full-path-to-csv-config-file)
     - [JSON format of Config file](#json-format-of-config-file)
   - [Step: Deployment Plan](#step-deployment-plan)
-  - [Step: Stoping triggers](#step-stoping-triggers)
+    - [DryRun / Plan output and CI usage](#dryrun--plan-output-and-ci-usage)
+  - [Step: Stopping triggers](#step-stopping-triggers)
   - [Step: Deployment of ADF objects](#step-deployment-of-adf-objects)
   - [Step: Save deployment state](#step-save-deployment-state)
   - [Step: Deleting objects not in source](#step-deleting-objects-not-in-source)
@@ -623,8 +624,45 @@ If you prefer using JSON rather than CSV for setting up configuration - JSON fil
 This step identifies objects to be deployed using `Includes` and `Excludes` list provided in *Publish Options*.  
 Afterwards, if `IncrementalDeployment = true`, it excludes objects by comparing hashes from **Deployment State** to hashed of awaiting objects.
 
+### DryRun / Plan output and CI usage
 
-## Step: Stoping triggers
+Use `-DryRun` or `-Plan` to preview intended changes without deploying. The process prints a terraform-like summary:
+
+```text
+Terraform-like plan (DryRun):
+Plan: 0 to add, 1 to change, 1 to destroy.
+
+  ~ Update
+    ~ pipeline.PL_ExecSparkJob
+
+  - Delete
+    - pipeline.PL_Obsolete
+
+  = Unchanged / skipped
+    = dataset.DS_Json
+```
+
+The returned object contains a `DryRunPlan` property, so CI can enforce policy checks before deployment:
+
+```powershell
+$result = Publish-AdfV2FromJson `
+  -RootFolder $RootFolder `
+  -ResourceGroupName $ResourceGroupName `
+  -DataFactoryName $DataFactoryName `
+  -Location $Location `
+  -Option $opt `
+  -Plan
+
+if ($result.DryRunPlan.Delete.Count -gt 0) {
+    Write-Error "Plan contains destroy actions. Review required before deployment."
+    exit 1
+}
+
+Write-Host "Plan accepted. Add=$($result.DryRunPlan.Create.Count); Change=$($result.DryRunPlan.Update.Count); Destroy=$($result.DryRunPlan.Delete.Count)"
+```
+
+
+## Step: Stopping triggers
 
 💬 In log you'll see line: `STEP: Stopping triggers...`
 

--- a/azure.datafactory.tools.psd1
+++ b/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.17.1'
+    ModuleVersion = '1.18.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.18.0] - 2026-07-01
+### Added
+* `Publish-AdfV2FromJson` now supports terraform-like planning via `-DryRun`/`-Plan`, including structured `DryRunPlan` output (Create/Update/Delete/Unchanged) #360
+
 ## [1.17.1] - 2026-07-01
 ### Fixed
 * Further fixes of `DeleteNotInSource` with deserialization issue #480 

--- a/docs/ADVANCED/CMDLET_REFERENCE.md
+++ b/docs/ADVANCED/CMDLET_REFERENCE.md
@@ -18,7 +18,8 @@ Publish-AdfV2FromJson `
     [-Stage <String>] `
     [-Option <AdfPublishOption>] `
     [-Method <String>] `
-    [-DryRun]
+    [-DryRun] `
+    [-Plan]
 ```
 
 **Parameters:**
@@ -33,6 +34,7 @@ Publish-AdfV2FromJson `
 | Option | AdfPublishOption | No | Publish options object (filtering, triggers, etc.) |
 | Method | String | No | Publishing method: 'AzDataFactory' or 'AzResource' (default) |
 | DryRun | Switch | No | Validate without deploying |
+| Plan | Switch | No | Alias behavior of DryRun with terraform-like naming |
 
 **Returns:** AdfPublishOption (deployment result)
 

--- a/docs/GUIDE/PUBLISHING.md
+++ b/docs/GUIDE/PUBLISHING.md
@@ -33,8 +33,11 @@ Publish-AdfV2FromJson `
    [-Stage] <String> `
    [-Option] <AdfPublishOption> `
    [-Method] <String> `
-   [-DryRun]
+   [-DryRun] `
+   [-Plan]
 ```
+
+`-Plan` is an alias behavior of `-DryRun` and prints a terraform-like plan without deploying.
 
 ### Complete Example
 

--- a/private/ApplyExclusionOptions.ps1
+++ b/private/ApplyExclusionOptions.ps1
@@ -127,10 +127,10 @@ function Get-DryRunPlan {
         [parameter(Mandatory = $false)] $targetAdfInstance
     )
 
-    $create = @()
-    $update = @()
-    $delete = @()
-    $unchanged = @()
+    $create = [System.Collections.Generic.List[string]]::new()
+    $update = [System.Collections.Generic.List[string]]::new()
+    $delete = [System.Collections.Generic.List[string]]::new()
+    $unchanged = [System.Collections.Generic.List[string]]::new()
 
     $sourceByName = @{}
     $adf.AllObjects() | ForEach-Object {
@@ -149,13 +149,13 @@ function Get-DryRunPlan {
     $adf.AllObjects() | ForEach-Object {
         $fullName = Get-AdfObjectFullName -Object $_
         if ($_.ToBeDeployed -eq $false) {
-            $unchanged += $fullName
+            $unchanged.Add($fullName) | Out-Null
         }
         elseif ($targetByName.ContainsKey($fullName)) {
-            $update += $fullName
+            $update.Add($fullName) | Out-Null
         }
         else {
-            $create += $fullName
+            $create.Add($fullName) | Out-Null
         }
     }
 
@@ -169,7 +169,7 @@ function Get-DryRunPlan {
                     $canDelete = !($oname.IsNameExcluded($adf.PublishOptions))
                 }
                 if ($canDelete) {
-                    $delete += $fullName
+                    $delete.Add($fullName) | Out-Null
                 }
             }
         }

--- a/private/ApplyExclusionOptions.ps1
+++ b/private/ApplyExclusionOptions.ps1
@@ -49,7 +49,9 @@ function ApplyExclusionOptions {
 
 function ToBeDeployedStat {
     param(
-        [Parameter(Mandatory=$True)] [Adf] $adf
+        [Parameter(Mandatory=$True)] [Adf] $adf,
+        [Parameter(Mandatory=$False)] $targetAdfInstance,
+        [switch] $TerraformStyle
     )
 
     $ToBeDeployedList = ($adf.AllObjects() | Where-Object { $_.ToBeDeployed -eq $true } | ToArray)
@@ -57,6 +59,168 @@ function ToBeDeployedStat {
     Write-Host "# Number of objects marked as to be deployed: $i/$($adf.AllObjects().Count)"
     $ToBeDeployedList | ForEach-Object {
         Write-Host "- $($_.FullName($true))"
+    }
+
+    if (!$TerraformStyle) {
+        return $null
+    }
+
+    $plan = Get-DryRunPlan -adf $adf -targetAdfInstance $targetAdfInstance
+    Write-DryRunPlan -plan $plan
+    return $plan
+
+}
+
+function ConvertTo-CanonicalAdfType {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        [String] $Type
+    )
+
+    $t = $Type.ToLowerInvariant()
+    switch ($t)
+    {
+        'pipeline' { return 'pipeline' }
+        'dataset' { return 'dataset' }
+        'dataflow' { return 'dataflow' }
+        'linkedservice' { return 'linkedService' }
+        'integrationruntime' { return 'integrationRuntime' }
+        'trigger' { return 'trigger' }
+        'factory' { return 'factory' }
+        'managedvirtualnetwork' { return 'managedVirtualNetwork' }
+        'managedprivateendpoint' { return 'managedPrivateEndpoint' }
+        'credential' { return 'credential' }
+        default { return $Type }
+    }
+}
+
+function Get-AdfObjectFullName {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        $Object
+    )
+
+    $name = $Object.Name
+    $simtype = ''
+
+    if ($Object -is [AdfObject]) {
+        $simtype = Get-SimplifiedType -Type $Object.Type
+        if ($Object.Type -like 'Microsoft.DataFactory/factories*') {
+            $simtype = ConvertTo-AdfType -AzType $Object.Type
+            $simtype = Get-SimplifiedType -Type $simtype
+        }
+    }
+    else {
+        $simtype = Get-SimplifiedType -Type $Object.GetType().Name
+    }
+
+    $simtype = ConvertTo-CanonicalAdfType -Type $simtype
+    return "$simtype.$name"
+}
+
+function Get-DryRunPlan {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)] [Adf] $adf,
+        [parameter(Mandatory = $false)] $targetAdfInstance
+    )
+
+    $create = @()
+    $update = @()
+    $delete = @()
+    $unchanged = @()
+
+    $sourceByName = @{}
+    $adf.AllObjects() | ForEach-Object {
+        $fullName = Get-AdfObjectFullName -Object $_
+        $sourceByName[$fullName] = $_
+    }
+
+    $targetByName = @{}
+    if ($null -ne $targetAdfInstance) {
+        $targetAdfInstance.AllObjects() | ForEach-Object {
+            $fullName = Get-AdfObjectFullName -Object $_
+            $targetByName[$fullName] = $_
+        }
+    }
+
+    $adf.AllObjects() | ForEach-Object {
+        $fullName = Get-AdfObjectFullName -Object $_
+        if ($_.ToBeDeployed -eq $false) {
+            $unchanged += $fullName
+        }
+        elseif ($targetByName.ContainsKey($fullName)) {
+            $update += $fullName
+        }
+        else {
+            $create += $fullName
+        }
+    }
+
+    if ($null -ne $targetAdfInstance -and $adf.PublishOptions.DeleteNotInSource) {
+        $targetByName.Keys | ForEach-Object {
+            $fullName = $_
+            if (!$sourceByName.ContainsKey($fullName)) {
+                $oname = [AdfObjectName]::new($fullName)
+                $canDelete = $true
+                if ($adf.PublishOptions.DoNotDeleteExcludedObjects) {
+                    $canDelete = !($oname.IsNameExcluded($adf.PublishOptions))
+                }
+                if ($canDelete) {
+                    $delete += $fullName
+                }
+            }
+        }
+    }
+
+    $create = @($create | Sort-Object)
+    $update = @($update | Sort-Object)
+    $delete = @($delete | Sort-Object)
+    $unchanged = @($unchanged | Sort-Object)
+
+    return [PSCustomObject]@{
+        Create = @($create)
+        Update = @($update)
+        Delete = @($delete)
+        Unchanged = @($unchanged)
+    }
+}
+
+function Write-DryRunPlan {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        $plan
+    )
+
+    Write-Host "==================================================================================="
+    Write-Host "Terraform-like plan (DryRun):"
+    Write-Host "Plan: $($plan.Create.Count) to add, $($plan.Update.Count) to change, $($plan.Delete.Count) to destroy."
+
+    if ($plan.Create.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  + Create"
+        $plan.Create | ForEach-Object { Write-Host "    + $_" }
+    }
+
+    if ($plan.Update.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  ~ Update"
+        $plan.Update | ForEach-Object { Write-Host "    ~ $_" }
+    }
+
+    if ($plan.Delete.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  - Delete"
+        $plan.Delete | ForEach-Object { Write-Host "    - $_" }
+    }
+
+    if ($plan.Unchanged.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  = Unchanged / skipped"
+        $plan.Unchanged | ForEach-Object { Write-Host "    = $_" }
     }
 
 }

--- a/public/Publish-AdfV2FromJson.ps1
+++ b/public/Publish-AdfV2FromJson.ps1
@@ -35,6 +35,9 @@ AzResource method has been introduced due to bugs in Az.DataFactory PS module.
 Optional switch parameter. When provided, process will not make any changes to target data factory but instead return the ADF object
 that would be used in deployment.
 
+.PARAMETER Plan
+Optional switch parameter. Alias for DryRun with terraform-style intent. Behaves the same as DryRun.
+
 .EXAMPLE
 # Publish entire ADF
 $ResourceGroupName = 'rg-devops-factory'
@@ -74,6 +77,10 @@ Publish-AdfV2FromJson -RootFolder "$RootFolder" -ResourceGroupName "$ResourceGro
 # Execute dry run of intended publishing changes
 Publish-AdfV2FromJson -RootFolder "$RootFolder" -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" -Location "$Location" -Stage "UAT" -DryRun
 
+.EXAMPLE
+# Execute plan (alias of DryRun) to preview intended changes
+Publish-AdfV2FromJson -RootFolder "$RootFolder" -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" -Location "$Location" -Stage "UAT" -Plan
+
 .LINK
 Online version: https://github.com/SQLPlayer/azure.datafactory.tools/
 #>
@@ -104,8 +111,15 @@ function Publish-AdfV2FromJson {
         [String]$Method = 'AzResource',
 
         [parameter(Mandatory = $false)]
-        [switch]$DryRun
+        [switch]$DryRun,
+
+        [parameter(Mandatory = $false)]
+        [switch]$Plan
     )
+
+    if ($Plan.IsPresent) {
+        $DryRun = $true
+    }
 
     $m = Get-Module -Name "azure.datafactory.tools"
     $verStr = $m.Version.ToString(2) + "." + $m.Version.Build.ToString("000");
@@ -123,6 +137,7 @@ function Publish-AdfV2FromJson {
     Write-Host "Options provided:   $($null -ne $Option)";
     Write-Host "Publishing method:  $Method";
     Write-Host "Is Dry Run?:        $($DryRun.IsPresent)";
+    Write-Host "Is Plan Mode?:      $($Plan.IsPresent)";
     Write-Host "======================================================================================";
     if ($null -ne $Option) {
         Write-Host "Options:"
@@ -248,10 +263,29 @@ function Publish-AdfV2FromJson {
         }
         Write-Host "Found $unchanged_count unchanged object(s)."
     }
-    ToBeDeployedStat -adf $adf
+
+    $dryRunPlan = $null
+    if ($DryRun.IsPresent) {
+        $targetAdfInstance = $null
+        try {
+            Write-Host "DRY RUN: Loading target ADF objects to classify plan changes..."
+            $targetAdfInstance = Get-AdfFromService -FactoryName "$DataFactoryName" -ResourceGroupName "$ResourceGroupName"
+        }
+        catch {
+            Write-Warning "DRY RUN: Unable to load target ADF state for full plan classification. Falling back to local-only plan. Details: $_"
+        }
+
+        $dryRunPlan = ToBeDeployedStat -adf $adf -targetAdfInstance $targetAdfInstance -TerraformStyle
+    }
+    else {
+        ToBeDeployedStat -adf $adf
+    }
 
     if ($DryRun.IsPresent) {
         Write-Host "DRY RUN: Terminating script pre-deployment - inspect returned object to review planned changes."
+        if ($null -ne $dryRunPlan) {
+            $adf | Add-Member -MemberType NoteProperty -Name DryRunPlan -Value $dryRunPlan -Force
+        }
         Write-Host "===================================================================================";
         return $adf
     }

--- a/test/Publish-AdfV2FromJson-DryRun.Tests.ps1
+++ b/test/Publish-AdfV2FromJson-DryRun.Tests.ps1
@@ -28,6 +28,10 @@ InModuleScope azure.datafactory.tools {
 
             Mock Set-StateToStorage {
             }
+
+            Mock Get-AdfFromService {
+                $null
+            }
         }
 
         It 'should still load deployment state from storage when DryRun is enabled' {
@@ -49,6 +53,65 @@ InModuleScope azure.datafactory.tools {
 
             Should -Invoke -CommandName Get-StateFromStorage -Times 1 -Exactly
             Should -Invoke -CommandName Set-StateToStorage -Times 0 -Exactly
+        }
+    }
+
+    Describe 'DryRun terraform-like plan output' -Tag 'Unit' {
+        It 'should classify add, change, destroy and expose DryRunPlan on returned object' {
+            $opt = New-AdfPublishOption
+            $opt.StopStartTriggers = $false
+            $opt.DeleteNotInSource = $true
+            $opt.DoNotDeleteExcludedObjects = $false
+            $opt.Includes.Add('pipeline.PL_ExecSparkJob', '')
+
+            Mock Get-AdfFromService {
+                $target = New-Object -TypeName AdfInstance
+                $target.Pipelines = @(
+                    [AdfPSPipeline]::new('PL_ExecSparkJob'),
+                    [AdfPSPipeline]::new('PL_Obsolete')
+                )
+                $target
+            }
+
+            $result = Publish-AdfV2FromJson `
+                -RootFolder $script:RootFolder `
+                -ResourceGroupName $script:ResourceGroupName `
+                -DataFactoryName $script:DataFactoryName `
+                -Location $script:Location `
+                -Option $opt `
+                -DryRun
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties.Name | Should -Contain 'DryRunPlan'
+
+            $plan = $result.DryRunPlan
+            $plan | Should -Not -BeNullOrEmpty
+            $plan.Update | Should -Contain 'pipeline.PL_ExecSparkJob'
+            $plan.Delete | Should -Contain 'pipeline.PL_Obsolete'
+            $plan.Unchanged | Should -Contain 'dataset.DS_Json'
+            $plan.Create.Count | Should -Be 0
+        }
+
+        It 'should support -Plan as an alias behavior of -DryRun' {
+            $opt = New-AdfPublishOption
+            $opt.StopStartTriggers = $false
+
+            Mock Get-AdfFromService {
+                $target = New-Object -TypeName AdfInstance
+                $target
+            }
+
+            $result = Publish-AdfV2FromJson `
+                -RootFolder $script:RootFolder `
+                -ResourceGroupName $script:ResourceGroupName `
+                -DataFactoryName $script:DataFactoryName `
+                -Location $script:Location `
+                -Option $opt `
+                -Plan
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties.Name | Should -Contain 'DryRunPlan'
+            $result.DryRunPlan | Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a major enhancement to the `Publish-AdfV2FromJson` cmdlet by adding a terraform-style planning mode for deployments, along with documentation updates and supporting code changes. The new `-Plan` switch (an alias for `-DryRun`) provides a clear, structured summary of intended changes (create, update, delete, unchanged) and exposes this plan for CI/CD policy enforcement. Documentation and tests have been updated to reflect and validate this new functionality.

**New Planning Feature:**

* Added a `-Plan` switch to `Publish-AdfV2FromJson`, acting as an alias for `-DryRun` but with terraform-style intent and output. The plan summarizes changes as create, update, delete, or unchanged, and the result object now includes a `DryRunPlan` property for CI/CD checks. [[1]](diffhunk://#diff-797e9222ace6fe3495226867af353cac28f89fa0cbfc39309e0cb1e68f336539R38-R40) [[2]](diffhunk://#diff-797e9222ace6fe3495226867af353cac28f89fa0cbfc39309e0cb1e68f336539R80-R83) [[3]](diffhunk://#diff-797e9222ace6fe3495226867af353cac28f89fa0cbfc39309e0cb1e68f336539L107-R123) [[4]](diffhunk://#diff-797e9222ace6fe3495226867af353cac28f89fa0cbfc39309e0cb1e68f336539R140) [[5]](diffhunk://#diff-797e9222ace6fe3495226867af353cac28f89fa0cbfc39309e0cb1e68f336539R266-R288) [[6]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R7-R10) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R189) [[8]](diffhunk://#diff-4839166448dd8a2270a4380854425230be5991ce5d78820660a94a83c8440055L21-R22) [[9]](diffhunk://#diff-4839166448dd8a2270a4380854425230be5991ce5d78820660a94a83c8440055R37) [[10]](diffhunk://#diff-f511c1aeb8abe3f9d92672f22316082087caded16ffe6dd1fe5bc8d39202c3efL36-R41) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R627-R665)

* Implemented supporting functions in `ApplyExclusionOptions.ps1` to generate and print the terraform-like plan, including detailed classification of objects. [[1]](diffhunk://#diff-d4af03064ef909d8510342487226d4bc7f9172df126e39c4aebc69eb8d207865L52-R54) [[2]](diffhunk://#diff-d4af03064ef909d8510342487226d4bc7f9172df126e39c4aebc69eb8d207865R64-R225)

**Documentation Updates:**

* Updated documentation (`README.md`, `CMDLET_REFERENCE.md`, `PUBLISHING.md`) to describe the new `-Plan` switch, its output format, and CI/CD usage examples. Also fixed a typo ("Stoping" → "Stopping"). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R79) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R189) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R627-R665) [[4]](diffhunk://#diff-4839166448dd8a2270a4380854425230be5991ce5d78820660a94a83c8440055L21-R22) [[5]](diffhunk://#diff-4839166448dd8a2270a4380854425230be5991ce5d78820660a94a83c8440055R37) [[6]](diffhunk://#diff-f511c1aeb8abe3f9d92672f22316082087caded16ffe6dd1fe5bc8d39202c3efL36-R41)

**Testing Enhancements:**

* Added unit tests to verify the new planning feature, ensuring correct classification and output, and that `-Plan` behaves as an alias for `-DryRun`. [[1]](diffhunk://#diff-7e64db6a95855a865bad0d0c6f87bccb0189acca6246e7c005fd06898126d493R31-R34) [[2]](diffhunk://#diff-7e64db6a95855a865bad0d0c6f87bccb0189acca6246e7c005fd06898126d493R58-R116)

**Other Changes:**

* Bumped the module version to `1.18.0` in `azure.datafactory.tools.psd1`.
* Updated the changelog to document the new feature and version.